### PR TITLE
[dataset] add CGD to AVAILABLE_DATASETS

### DIFF
--- a/mimic-it/syphus/abstract_dataset.py
+++ b/mimic-it/syphus/abstract_dataset.py
@@ -5,6 +5,7 @@ import json
 
 AVAILABLE_DATASETS: List[str] = [
     "change.SpotTheDifference",
+    "change.CocoSpotTheDifference",
     "video.DenseCaptions",
     "video.TVCaptions",
     "video.VisualStoryTelling",


### PR DESCRIPTION
add CGD to AVAILABLE_DATASETS, to make syphus runnable for CGD


Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [x] A descriptive title: [xxx] XXXX
- [x] A detailed description
- [x] Assign an issue type tag (label):
  - `dataset` (mimic-it download, usage, etc.),
  - `demo` (online demo),
  - `doc` (readme, wiki, paper, video, etc.),
  - `evaluation` (evaluation result, performance of Otter, etc.),
  - `model` (model configuration, components, etc.),
  - `train` (training configuration, process, code, etc.)

Thank you for your contributions!
