### PR TITLE
[training] Change current data related args to a yaml file

### DIFF
--- a/pipeline/mimicit_utils/mimicit_dataset.py
+++ b/pipeline/mimicit_utils/mimicit_dataset.py
@@ -491,9 +491,7 @@ class MimicitDataset(Dataset):
         if cur_train_id.upper().startswith("LA"):
             patch_images, all_texts = self.process_llava(instruction_id, instruction, answer, image_ids, in_context_example_ids, inst_format=inst_format)
         elif cur_train_id.upper().startswith("SD") or cur_train_id.startswith("CGD"):
-            patch_images, all_texts = self.process_spot_the_difference(
-                instruction_id, instruction, answer, image_ids, in_context_example_ids #, inst_format=inst_format
-            )
+            patch_images, all_texts = self.process_spot_the_difference(instruction_id, instruction, answer, image_ids, in_context_example_ids)
         elif cur_train_id.upper().startswith("SN"):
             patch_images, all_texts = self.process_scene_navigation(
                 instruction_id, instruction, answer, image_ids, in_context_example_ids, inst_format=inst_format

--- a/pipeline/mimicit_utils/mimicit_dataset.py
+++ b/pipeline/mimicit_utils/mimicit_dataset.py
@@ -360,7 +360,7 @@ class MimicitDataset(Dataset):
 
         patch_images = patch_images.unsqueeze(0)
         instruction = self.pre_question(instruction)
-        answer = self.pre_answer(answer, self.max_tgt_length)
+        answer = self.pre_answer(answer)
         query_text = f"<image>User: {instruction} GPT:<answer> {answer}<|endofchunk|>"
         all_texts = f"{incontext_text}{query_text}"
         return patch_images, all_texts
@@ -372,7 +372,7 @@ class MimicitDataset(Dataset):
             cur_incontext_instruction = self.dataset[cur_incontext_id]["instruction"]
             cur_incontext_instruction = self.pre_question(cur_incontext_instruction)
             cur_incontext_answer = self.dataset[cur_incontext_id]["answer"]
-            cur_incontext_answer = self.pre_answer(cur_incontext_answer, self.max_tgt_length)
+            cur_incontext_answer = self.pre_answer(cur_incontext_answer)
             cur_incontext_text = f"User: {cur_incontext_instruction} GPT:<answer> {cur_incontext_answer}<|endofchunk|>"
             incontext_text += cur_incontext_text
 
@@ -389,7 +389,7 @@ class MimicitDataset(Dataset):
 
         patch_images = patch_images.unsqueeze(0)
         instruction = self.pre_question(instruction)
-        answer = self.pre_answer(answer, self.max_tgt_length)
+        answer = self.pre_answer(answer)
         query_text = f"User: {instruction} GPT:<answer> {answer}<|endofchunk|>"
         all_texts = f"{incontext_text}{all_texts}"
         return patch_images, all_texts
@@ -492,7 +492,7 @@ class MimicitDataset(Dataset):
             patch_images, all_texts = self.process_llava(instruction_id, instruction, answer, image_ids, in_context_example_ids, inst_format=inst_format)
         elif cur_train_id.upper().startswith("SD") or cur_train_id.startswith("CGD"):
             patch_images, all_texts = self.process_spot_the_difference(
-                instruction_id, instruction, answer, image_ids, in_context_example_ids, inst_format=inst_format
+                instruction_id, instruction, answer, image_ids, in_context_example_ids #, inst_format=inst_format
             )
         elif cur_train_id.upper().startswith("SN"):
             patch_images, all_texts = self.process_scene_navigation(

--- a/pipeline/train/config.yaml
+++ b/pipeline/train/config.yaml
@@ -1,5 +1,7 @@
-training_data:
-  - mimicit: /home/luodian/projects/Otter/archived/VideoQA_Instruction.json
-    images: /home/luodian/projects/Otter/archived/VideoQA_Images.json
-  - mimicit: /home/luodian/projects/data/DC/DC_instructions.json
-    images: /home/luodian/projects/data/DC/DC_images.json
+mimicit_vt_path:
+  - /data/pufanyi/training_data/SD/SD_instructions.json
+  - /data/pufanyi/training_data/CGD/CGD_instructions.json
+
+images_vt_path:
+  - /data/pufanyi/training_data/SD/SD.json
+  - /data/pufanyi/training_data/CGD/CGD.json

--- a/pipeline/train/config.yaml
+++ b/pipeline/train/config.yaml
@@ -1,0 +1,5 @@
+training_data:
+  - mimicit: /home/luodian/projects/Otter/archived/VideoQA_Instruction.json
+    images: /home/luodian/projects/Otter/archived/VideoQA_Images.json
+  - mimicit: /home/luodian/projects/data/DC/DC_instructions.json
+    images: /home/luodian/projects/data/DC/DC_images.json

--- a/pipeline/train/data.py
+++ b/pipeline/train/data.py
@@ -17,7 +17,6 @@ import torch
 import torch.utils
 import torchvision
 import webdataset as wds
-from typing import List, Iterable
 from PIL import Image, ImageSequence, ImageFile
 from torch.utils.data import DataLoader, IterableDataset, RandomSampler, get_worker_info
 from torch.utils.data.distributed import DistributedSampler

--- a/pipeline/train/data.py
+++ b/pipeline/train/data.py
@@ -7,7 +7,7 @@ import math
 import os
 import random
 import sys
-import tarfile
+import yaml
 from dataclasses import dataclass
 from multiprocessing import Value
 import numpy as np
@@ -17,6 +17,7 @@ import torch
 import torch.utils
 import torchvision
 import webdataset as wds
+from typing import List, Iterable
 from PIL import Image, ImageSequence, ImageFile
 from torch.utils.data import DataLoader, IterableDataset, RandomSampler, get_worker_info
 from torch.utils.data.distributed import DistributedSampler
@@ -647,6 +648,19 @@ def get_mimicit_dataset(args, image_processor, tokenizer, epoch=0, floor=False):
     args.task = "pretrain"
     args.tokenizer = tokenizer
     unified_datasets = []
+
+    def append_datasets(args, dataset_config_dict):
+        for name, data in dataset_config_dict.items():
+            if getattr(args, name) == "":
+                setattr(args, name, ",".join(data))
+            else:
+                setattr(args, name, ",".join(data + [getattr(args, name)]))
+
+    if args.training_data_yaml != "":
+        with open(args.training_data_yaml, "r") as f:
+            dataset_config_dict = yaml.safe_load(f)
+            append_datasets(args, dataset_config_dict)
+
     # processing for image-text in-context datasets
     if args.mimicit_ic_path != "":
         all_mimicit_ic_path = (

--- a/pipeline/train/instruction_following.py
+++ b/pipeline/train/instruction_following.py
@@ -391,6 +391,12 @@ def parse_args():
 
     # Arguments for video-text data.
     parser.add_argument(
+        "--training_data_yaml",
+        type=str,
+        default="",
+        help="Path to the training data yaml file.",
+    )
+    parser.add_argument(
         "--past_mimicit_vt_path",
         type=str,
         default="",

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ yajl>=0.3.5
 deepspeed>=0.10.0
 wandb>=0.15.8
 trl>=0.5.0
+pyyaml>=6.0.1


### PR DESCRIPTION
## Description

To simplify the execution of the loading script, there's no requirement to input the paths for all datasets via the command line. Instead, you can facilitate the process by adding the argument `--training_data_yaml=pipeline/train/config.yaml`.

In the configuration YAML file, structure your entries as follows:

```yaml
old_command_1:
  - path_to_dataset_1_1
  - path_to_dataset_1_2
 
old_command_2:
  - path_to_dataset_2_1
  - path_to_dataset_2_2
```

For instance:

```yaml
mimicit_vt_path:
  - /data/pufanyi/training_data/SD/SD_instructions.json
  - /data/pufanyi/training_data/CGD/CGD_instructions.json

images_vt_path:
  - /data/pufanyi/training_data/SD/SD.json
  - /data/pufanyi/training_data/CGD/CGD.json
```

No changes are necessary for the previous script; commands such as `mimicit_vt_path` remain compatible.
## Checklist

Before you open a pull-request, please check if a similar issue already exists or has been closed before.

### When you open a pull-request, please be sure to include the following

- [x] A descriptive title: [xxx] XXXX
- [x] A detailed description
- [x] Assign an issue type tag (label):
  - `dataset` (mimic-it download, usage, etc.),
  - `demo` (online demo),
  - `doc` (readme, wiki, paper, video, etc.),
  - `evaluation` (evaluation result, performance of Otter, etc.),
  - `model` (model configuration, components, etc.),
  - `train` (training configuration, process, code, etc.)

Thank you for your contributions!
